### PR TITLE
Various UX and services management enhancements

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "dev": "run-p dev:*",
     "lint": "tsc",
     "prebuild": "rimraf -g dist/*",
-    "build": "esbuild src/main.ts --bundle --platform=node --outfile=dist/app.js"
+    "build": "node scripts/build.mjs"
   },
   "dependencies": {
     "axios": "^1.13.5",

--- a/backend/scripts/build.mjs
+++ b/backend/scripts/build.mjs
@@ -1,0 +1,50 @@
+import { context, build } from 'esbuild';
+import { statSync } from 'node:fs';
+
+const OUTFILE = 'dist/app.js';
+const SIZE_WARNING_LIMIT_MB = 2.5;
+const SIZE_WARNING_LIMIT_BYTES = SIZE_WARNING_LIMIT_MB * 1024 * 1024;
+const isWatch = process.argv.includes('--watch');
+
+function printSizeWarning() {
+  const size = statSync(OUTFILE).size;
+  if (size > SIZE_WARNING_LIMIT_BYTES) {
+    const sizeMb = (size / (1024 * 1024)).toFixed(1);
+    console.warn(
+      `⚠️  ${OUTFILE} is ${sizeMb}mb (configured warning limit: ${SIZE_WARNING_LIMIT_MB}mb)`
+    );
+  }
+}
+
+const options = {
+  bundle: true,
+  entryPoints: ['src/main.ts'],
+  outfile: OUTFILE,
+  platform: 'node',
+  // Use warning level so esbuild doesn't print its hardcoded 1mb info summary.
+  logLevel: 'warning',
+};
+
+if (isWatch) {
+  const ctx = await context({
+    ...options,
+    plugins: [
+      {
+        name: 'custom-size-warning',
+        setup(buildApi) {
+          buildApi.onEnd((result) => {
+            if (result.errors.length === 0) {
+              printSizeWarning();
+            }
+          });
+        },
+      },
+    ],
+  });
+
+  await ctx.watch();
+  console.log(`Watching... (size warning limit: ${SIZE_WARNING_LIMIT_MB}mb)`);
+} else {
+  await build(options);
+  printSizeWarning();
+}

--- a/frontend/src/api/application.ts
+++ b/frontend/src/api/application.ts
@@ -62,4 +62,11 @@ export default {
       authorization: useAuthStore().getAuthorization,
     });
   },
+  delete: async (guid: CFApplication['guid']) => {
+    return handleApiCall({
+      path: `/v3/apps/${guid}`,
+      method: 'DELETE',
+      authorization: useAuthStore().getAuthorization,
+    });
+  },
 };

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -2,7 +2,7 @@ import { HttpMethod } from '@/models/common';
 import { arrayOfNotFalsy } from '@/utils/array';
 import { Result } from '@/utils/result';
 import { absoluteOrRelativeURL } from '@/utils/url';
-import { uniq } from 'lodash';
+import { uniqBy } from 'lodash';
 
 const serverUrl: string = import.meta.env.VITE_SERVER_URL || '';
 
@@ -103,7 +103,10 @@ export const queryParams = (params: Record<string, any>): Record<string, any> =>
 };
 
 export const compactErrors = (...errors: (ApiErrorResponse | undefined | false)[]): ApiErrorResponse | undefined => {
-  const flattenErrors = uniq(arrayOfNotFalsy(...errors).flatMap((error) => error.errors));
+  const flattenErrors = uniqBy(
+    arrayOfNotFalsy(...errors).flatMap((error) => error.errors),
+    (error) => `${error.code}|${error.title}|${error.detail}`,
+  );
   return flattenErrors.length > 0 ? { errors: flattenErrors } : undefined;
 };
 

--- a/frontend/src/api/service.ts
+++ b/frontend/src/api/service.ts
@@ -33,4 +33,11 @@ export default {
       authorization: useAuthStore().getAuthorization,
     });
   },
+  deleteBinding: async (guid: CFServiceBinding['guid']) => {
+    return await handleApiCall({
+      path: `/v3/service_credential_bindings/${guid}`,
+      method: 'DELETE',
+      authorization: useAuthStore().getAuthorization,
+    });
+  },
 };

--- a/frontend/src/api/service.ts
+++ b/frontend/src/api/service.ts
@@ -1,4 +1,4 @@
-import { handleApiCall } from '@/api';
+import { handleApiCall, queryParams } from '@/api';
 import { CFApplication } from '@/models/cf/application';
 import {
   CFServiceBinding,
@@ -9,11 +9,30 @@ import {
 import { useAuthStore } from '@/stores/auth';
 
 export default {
+  getAllInstances: async (options?: Partial<{ page: number; perPage: number }>) => {
+    return await handleApiCall<PaginatedServiceInstances>({
+      path: `/v3/service_instances`,
+      query: queryParams({
+        page: options?.page,
+        per_page: options?.perPage,
+      }),
+      authorization: useAuthStore().getAuthorization,
+    });
+  },
   getBindingsForApplication: async (guid: CFApplication['guid']) => {
     return await handleApiCall<PaginatedServiceBindings>({
       path: `/v3/service_credential_bindings`,
       query: {
         app_guids: [guid],
+      },
+      authorization: useAuthStore().getAuthorization,
+    });
+  },
+  getBindingsForInstance: async (guid: CFServiceInstance['guid']) => {
+    return await handleApiCall<PaginatedServiceBindings>({
+      path: `/v3/service_credential_bindings`,
+      query: {
+        service_instance_guids: [guid],
       },
       authorization: useAuthStore().getAuthorization,
     });
@@ -36,6 +55,13 @@ export default {
   deleteBinding: async (guid: CFServiceBinding['guid']) => {
     return await handleApiCall({
       path: `/v3/service_credential_bindings/${guid}`,
+      method: 'DELETE',
+      authorization: useAuthStore().getAuthorization,
+    });
+  },
+  deleteInstance: async (guid: CFServiceInstance['guid']) => {
+    return await handleApiCall({
+      path: `/v3/service_instances/${guid}`,
       method: 'DELETE',
       authorization: useAuthStore().getAuthorization,
     });

--- a/frontend/src/api/space.ts
+++ b/frontend/src/api/space.ts
@@ -1,14 +1,15 @@
-import { handleApiCall } from '@/api';
+import { handleApiCall, queryParams } from '@/api';
 import { CFSpace, PaginatedSpaces } from '@/models/cf/space';
 import { useAuthStore } from '@/stores/auth';
 
 export default {
-  getAll: async () => {
+  getAll: async (options?: Partial<{ page: number; perPage: number }>) => {
     return handleApiCall<PaginatedSpaces>({
       path: '/v3/spaces',
-      query: {
-        per_page: 200,
-      },
+      query: queryParams({
+        page: options?.page,
+        per_page: options?.perPage ?? 200,
+      }),
       authorization: useAuthStore().getAuthorization,
     });
   },

--- a/frontend/src/components/ApiErrorAlert.vue
+++ b/frontend/src/components/ApiErrorAlert.vue
@@ -1,14 +1,37 @@
 <script setup lang="ts">
 import { ApiErrorResponse } from '@/api';
-import { DeepReadonly } from 'vue';
+import { computed, DeepReadonly, ref, watch } from 'vue';
 
-defineProps<{
+const props = defineProps<{
   error: ApiErrorResponse | DeepReadonly<ApiErrorResponse>;
 }>();
+
+const dismissed = ref<Set<string>>(new Set());
+const errorKey = (error: ApiErrorResponse['errors'][number]) => `${error.code}|${error.title}|${error.detail}`;
+
+watch(
+  () => props.error.errors,
+  (errors) => {
+    const existingKeys = new Set(errors.map(errorKey));
+    dismissed.value = new Set([...dismissed.value].filter((key) => existingKeys.has(key)));
+  },
+  { deep: true, immediate: true },
+);
+
+const visibleErrors = computed(() => props.error.errors.filter((error) => !dismissed.value.has(errorKey(error))));
+const dismiss = (error: ApiErrorResponse['errors'][number]) => {
+  dismissed.value.add(errorKey(error));
+};
 </script>
 
 <template>
-  <v-alert density="compact" type="error" v-for="(e, index) in error.errors" :key="`error-${index}`">
+  <v-alert
+    density="compact"
+    type="error"
+    closable
+    v-for="(e, index) in visibleErrors"
+    :key="`error-${index}`"
+    @click:close="dismiss(e)">
     <v-alert-title>{{ e.code }} {{ e.title }}</v-alert-title>
     {{ e.detail }}
   </v-alert>

--- a/frontend/src/components/application/action/DeleteButton.vue
+++ b/frontend/src/components/application/action/DeleteButton.vue
@@ -21,12 +21,20 @@ const emits = defineEmits<{
 const loading = ref(false);
 const dialog = ref(false);
 const isDisabled = computed(() => props.disabled || loading.value);
+const wait = (delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs));
 
 const { fn: confirmDelete } = useLoadingFn(async () => {
   emits('launched');
 
   const result = await applicationApi.delete(props.application.guid);
   if (result.success) {
+    for (let i = 0; i < 20; i++) {
+      const appResult = await applicationApi.getOne(props.application.guid);
+      if (!appResult.success) {
+        break;
+      }
+      await wait(1000);
+    }
     dialog.value = false;
     emits('success');
   } else {

--- a/frontend/src/components/application/action/DeleteButton.vue
+++ b/frontend/src/components/application/action/DeleteButton.vue
@@ -1,21 +1,51 @@
 <script setup lang="ts">
 import useLoadingFn from '@/composables/useLoadingFn';
+import applicationApi from '@/api/application';
+import { ApiErrorResponse } from '@/api';
+import ConfirmDialog from '@/components/shared/ConfirmDialog.vue';
 import { CFApplication } from '@/models/cf/application';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 const props = defineProps<{
   application: CFApplication;
   disabled?: boolean;
 }>();
 
-const loading = ref(false);
+const emits = defineEmits<{
+  (e: 'launched'): void;
+  (e: 'completed'): void;
+  (e: 'success'): void;
+  (e: 'error', error: ApiErrorResponse): void;
+}>();
 
-const { fn: launchDelete } = useLoadingFn(async () => {}, loading);
+const loading = ref(false);
+const dialog = ref(false);
+const isDisabled = computed(() => props.disabled || loading.value);
+
+const { fn: confirmDelete } = useLoadingFn(async () => {
+  emits('launched');
+
+  const result = await applicationApi.delete(props.application.guid);
+  if (result.success) {
+    dialog.value = false;
+    emits('success');
+  } else {
+    emits('error', result.error);
+  }
+
+  emits('completed');
+}, loading);
 </script>
 
 <template>
-  <v-btn @click="launchDelete" :loading="loading" :disabled="disabled">
+  <v-btn @click="dialog = true" :loading="loading" :disabled="isDisabled">
     <v-icon>mdi-delete-outline</v-icon>
     <v-tooltip activator="parent" location="bottom">Delete</v-tooltip>
   </v-btn>
+
+  <confirm-dialog v-model="dialog" @confirm="confirmDelete" :loading="loading">
+    <template #text>
+      Delete application `{{ application.name }}`?
+    </template>
+  </confirm-dialog>
 </template>

--- a/frontend/src/components/layout/TheDrawer.vue
+++ b/frontend/src/components/layout/TheDrawer.vue
@@ -29,6 +29,7 @@ const compact = computed(() => {
 
 const menus = computed<MenuItem[]>(() => [
   { label: t('menu.applications'), route: { name: RouteNames.APPLICATIONS }, icon: 'mdi-view-dashboard' },
+  { label: t('menu.services'), route: { name: RouteNames.SERVICES }, icon: 'mdi-database-outline' },
   { label: t('menu.organizations'), route: { name: RouteNames.ORGANIZATIONS }, icon: 'mdi-file-tree-outline' },
 ]);
 

--- a/frontend/src/components/services/ServiceCardItem.vue
+++ b/frontend/src/components/services/ServiceCardItem.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
-import { CFServiceInstance } from '@/models/cf/service';
+import { ServiceWithBinding } from '@/components/services/models';
 import { formatDate } from '@/utils/date';
 import { computed } from 'vue';
 
 const props = defineProps<{
-  service: CFServiceInstance;
+  service: ServiceWithBinding;
+  deleting?: boolean;
+}>();
+
+const emits = defineEmits<{
+  (e: 'open'): void;
+  (e: 'delete'): void;
 }>();
 
 const progressColor = computed(() => {
@@ -22,7 +28,7 @@ const progressColor = computed(() => {
 </script>
 
 <template>
-  <v-card density="compact">
+  <v-card density="compact" @click="emits('open')">
     <v-progress-linear
       :color="progressColor"
       model-value="100"
@@ -47,5 +53,18 @@ const progressColor = computed(() => {
         <v-col cols="auto">{{ formatDate(service.updated_at, 'DD/MM/YYYY HH:mm:ss') }}</v-col>
       </v-row>
     </v-card-text>
+
+    <v-card-actions class="justify-end">
+      <v-btn
+        color="warning"
+        variant="text"
+        size="small"
+        :loading="deleting"
+        :disabled="deleting"
+        @click.stop="emits('delete')">
+        <v-icon>mdi-delete-outline</v-icon>
+        <v-tooltip activator="parent" location="bottom">Delete service from app</v-tooltip>
+      </v-btn>
+    </v-card-actions>
   </v-card>
 </template>

--- a/frontend/src/components/services/ServiceInstanceCardItem.vue
+++ b/frontend/src/components/services/ServiceInstanceCardItem.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { CFServiceInstance } from '@/models/cf/service';
+import { formatDate } from '@/utils/date';
+import { computed } from 'vue';
+
+type RelatedResource = {
+  guid: string;
+  name: string;
+};
+
+const props = defineProps<{
+  service: CFServiceInstance & { space?: RelatedResource; organization?: RelatedResource };
+  deleting?: boolean;
+}>();
+
+const emits = defineEmits<{
+  (e: 'delete'): void;
+}>();
+
+const progressColor = computed(() => {
+  switch (props.service.last_operation.state) {
+    case 'initial':
+      return 'grey';
+    case 'succeeded':
+      return 'success';
+    case 'in progress':
+      return 'info';
+    case 'failed':
+      return 'warning';
+  }
+});
+</script>
+
+<template>
+  <v-card density="compact">
+    <v-progress-linear
+      :color="progressColor"
+      model-value="100"
+      :indeterminate="service.last_operation.state === 'in progress'">
+    </v-progress-linear>
+
+    <v-card-title :title="service.name">{{ service.name }}</v-card-title>
+
+    <v-card-text>
+      <v-row class="justify-space-between" dense>
+        <v-col>Organisation</v-col>
+        <v-col cols="auto">{{ service.organization?.name ?? '--' }}</v-col>
+      </v-row>
+
+      <v-row class="justify-space-between" dense>
+        <v-col>Space</v-col>
+        <v-col cols="auto">{{ service.space?.name ?? '--' }}</v-col>
+      </v-row>
+
+      <v-row class="justify-space-between" dense>
+        <v-col>Dernière opération</v-col>
+        <v-col cols="auto">{{ service.last_operation.type }} / {{ service.last_operation.state }}</v-col>
+      </v-row>
+
+      <v-row class="justify-space-between" dense>
+        <v-col>Création</v-col>
+        <v-col cols="auto">{{ formatDate(service.created_at, 'DD/MM/YYYY HH:mm:ss') }}</v-col>
+      </v-row>
+
+      <v-row class="justify-space-between" dense>
+        <v-col>Mise à jour</v-col>
+        <v-col cols="auto">{{ formatDate(service.updated_at, 'DD/MM/YYYY HH:mm:ss') }}</v-col>
+      </v-row>
+    </v-card-text>
+
+    <v-card-actions class="justify-end">
+      <v-btn
+        color="warning"
+        variant="text"
+        size="small"
+        :loading="deleting"
+        :disabled="deleting"
+        @click.stop="emits('delete')">
+        <v-icon>mdi-delete-outline</v-icon>
+        <v-tooltip activator="parent" location="bottom">Delete service instance</v-tooltip>
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>

--- a/frontend/src/components/services/ServicesDashboard.vue
+++ b/frontend/src/components/services/ServicesDashboard.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
+import { ApiErrorResponse } from '@/api';
 import serviceApi from '@/api/service';
 import ServiceCardDetails from '@/components/services/ServiceCardDetails.vue';
 import ServiceCardItem from '@/components/services/ServiceCardItem.vue';
+import ConfirmDialog from '@/components/shared/ConfirmDialog.vue';
 import { ServiceDetails, ServiceWithBinding } from '@/components/services/models';
 import useApiCall from '@/composables/useApiCall';
 import useApplicationContext from '@/composables/useApplicationContext';
 import useFilterData from '@/composables/useFilterData';
+import useLoadingFn from '@/composables/useLoadingFn';
 import { mapResources } from '@/models/cf/common';
 import { onSuccess, successOf } from '@/utils/result';
 import { ref } from 'vue';
@@ -72,6 +75,27 @@ const { data: filteredServices, filters } = useFilterData((filters, { includesTe
 });
 
 const dialog = ref<DialogState>({ opened: false, service: undefined });
+const deleting = ref(false);
+const deletingBindingGuid = ref<ServiceWithBinding['binding']['guid']>();
+const deleteDialog = ref<{ opened: boolean; service?: ServiceWithBinding }>({ opened: false, service: undefined });
+
+const wait = (delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs));
+const waitForBindingDeletion = async (bindingGuid: ServiceWithBinding['binding']['guid']) => {
+  for (let i = 0; i < 20; i++) {
+    const result = await serviceApi.getBindingsForApplication(context.guid.value);
+    if (!result.success) {
+      break;
+    }
+
+    const exists = result.data.resources.some((binding) => binding.guid === bindingGuid);
+    if (!exists) {
+      return;
+    }
+
+    await wait(1000);
+  }
+};
+
 const openService = async (service: ServiceWithBinding) => {
   context.loading.value = true;
 
@@ -87,6 +111,27 @@ const openService = async (service: ServiceWithBinding) => {
 
   context.loading.value = false;
 };
+
+const requestDeleteService = (service: ServiceWithBinding) => {
+  deleteDialog.value = { opened: true, service };
+};
+
+const { fn: confirmDeleteService } = useLoadingFn(async () => {
+  const service = deleteDialog.value.service;
+  if (!service) return;
+
+  deletingBindingGuid.value = service.binding.guid;
+  const result = await serviceApi.deleteBinding(service.binding.guid);
+  if (result.success) {
+    await waitForBindingDeletion(service.binding.guid);
+    deleteDialog.value = { opened: false, service: undefined };
+    loadData();
+  } else {
+    context.errors.value.push(result.error as ApiErrorResponse);
+  }
+
+  deletingBindingGuid.value = undefined;
+}, deleting);
 </script>
 
 <template>
@@ -95,6 +140,13 @@ const openService = async (service: ServiceWithBinding) => {
       <v-dialog v-model="dialog.opened" width="80%" scrollable>
         <service-card-details v-if="dialog.service" :service="dialog.service"></service-card-details>
       </v-dialog>
+
+      <confirm-dialog v-model="deleteDialog.opened" @confirm="confirmDeleteService" :loading="deleting">
+        <template #text>
+          Delete service `{{ deleteDialog.service?.name }}` from application `{{ context.application.value.name }}`?
+          This removes the binding from this app.
+        </template>
+      </confirm-dialog>
 
       <v-row justify="end">
         <v-col cols="3">
@@ -112,7 +164,12 @@ const openService = async (service: ServiceWithBinding) => {
 
       <v-row>
         <v-col cols="3" v-for="service in filteredServices" :key="`application-${service.guid}`">
-          <service-card-item :service="service" @click="openService(service)"></service-card-item>
+          <service-card-item
+            :service="service"
+            :deleting="deletingBindingGuid === service.binding.guid"
+            @open="openService(service)"
+            @delete="requestDeleteService(service)">
+          </service-card-item>
         </v-col>
       </v-row>
     </v-col>

--- a/frontend/src/components/services/ServicesDashboard.vue
+++ b/frontend/src/components/services/ServicesDashboard.vue
@@ -11,7 +11,7 @@ import useFilterData from '@/composables/useFilterData';
 import useLoadingFn from '@/composables/useLoadingFn';
 import { mapResources } from '@/models/cf/common';
 import { onSuccess, successOf } from '@/utils/result';
-import { ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 type DialogState =
   | {
@@ -73,6 +73,59 @@ const { data: filteredServices, filters } = useFilterData((filters, { includesTe
     return !filters.text || includesText(service.name);
   });
 });
+const cardsPerRow = ref<1 | 2 | 4>(4);
+const layoutManuallySelected = ref(false);
+const suggestedCardsPerRow = (count: number): 1 | 2 | 4 => {
+  if (count <= 1) return 1;
+  if (count < 4) return 2;
+  return 4;
+};
+const cardCols = computed(() => {
+  switch (cardsPerRow.value) {
+    case 1:
+      return 12;
+    case 2:
+      return 6;
+    case 4:
+    default:
+      return 3;
+  }
+});
+const cycleCardsPerRow = () => {
+  layoutManuallySelected.value = true;
+  switch (cardsPerRow.value) {
+    case 4:
+      cardsPerRow.value = 2;
+      break;
+    case 2:
+      cardsPerRow.value = 1;
+      break;
+    case 1:
+    default:
+      cardsPerRow.value = 4;
+      break;
+  }
+};
+const cardsPerRowIcon = computed(() => {
+  switch (cardsPerRow.value) {
+    case 4:
+      return 'mdi-view-grid-outline';
+    case 2:
+      return 'mdi-view-agenda-outline';
+    case 1:
+    default:
+      return 'mdi-view-stream-outline';
+  }
+});
+watch(
+  () => filteredServices.value.length,
+  (count) => {
+    if (!layoutManuallySelected.value) {
+      cardsPerRow.value = suggestedCardsPerRow(count);
+    }
+  },
+  { immediate: true },
+);
 
 const dialog = ref<DialogState>({ opened: false, service: undefined });
 const deleting = ref(false);
@@ -212,11 +265,18 @@ const { fn: confirmDeleteService } = useLoadingFn(async () => {
           </v-btn>
         </v-col>
 
+        <v-col cols="auto">
+          <v-btn variant="text" @click="cycleCardsPerRow" size="large">
+            <v-icon>{{ cardsPerRowIcon }}</v-icon>
+            <v-tooltip activator="parent" location="bottom">Cards per row: {{ cardsPerRow }}</v-tooltip>
+          </v-btn>
+        </v-col>
+
         <v-col cols="auto">{{ filteredServices.length }}/{{ services.resources.length }}</v-col>
       </v-row>
 
       <v-row>
-        <v-col cols="3" v-for="service in filteredServices" :key="`application-${service.guid}`">
+        <v-col cols="12" :md="cardCols" v-for="service in filteredServices" :key="`application-${service.guid}`">
           <service-card-item
             :service="service"
             :deleting="deletingBindingGuid === service.binding.guid"

--- a/frontend/src/components/services/ServicesDashboard.vue
+++ b/frontend/src/components/services/ServicesDashboard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ApiErrorResponse } from '@/api';
+import { ApiErrorResponse, buildApiErrorResponse } from '@/api';
 import serviceApi from '@/api/service';
 import ServiceCardDetails from '@/components/services/ServiceCardDetails.vue';
 import ServiceCardItem from '@/components/services/ServiceCardItem.vue';
@@ -77,7 +77,11 @@ const { data: filteredServices, filters } = useFilterData((filters, { includesTe
 const dialog = ref<DialogState>({ opened: false, service: undefined });
 const deleting = ref(false);
 const deletingBindingGuid = ref<ServiceWithBinding['binding']['guid']>();
-const deleteDialog = ref<{ opened: boolean; service?: ServiceWithBinding }>({ opened: false, service: undefined });
+const deleteDialog = ref<{ opened: boolean; service?: ServiceWithBinding; deleteInstance: boolean }>({
+  opened: false,
+  service: undefined,
+  deleteInstance: false,
+});
 
 const wait = (delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs));
 const waitForBindingDeletion = async (bindingGuid: ServiceWithBinding['binding']['guid']) => {
@@ -88,6 +92,22 @@ const waitForBindingDeletion = async (bindingGuid: ServiceWithBinding['binding']
     }
 
     const exists = result.data.resources.some((binding) => binding.guid === bindingGuid);
+    if (!exists) {
+      return;
+    }
+
+    await wait(1000);
+  }
+};
+
+const waitForServiceInstanceDeletion = async (serviceGuid: ServiceWithBinding['guid']) => {
+  for (let i = 0; i < 20; i++) {
+    const result = await serviceApi.getInstances([serviceGuid]);
+    if (!result.success) {
+      break;
+    }
+
+    const exists = result.data.resources.some((service) => service.guid === serviceGuid);
     if (!exists) {
       return;
     }
@@ -113,7 +133,7 @@ const openService = async (service: ServiceWithBinding) => {
 };
 
 const requestDeleteService = (service: ServiceWithBinding) => {
-  deleteDialog.value = { opened: true, service };
+  deleteDialog.value = { opened: true, service, deleteInstance: false };
 };
 
 const { fn: confirmDeleteService } = useLoadingFn(async () => {
@@ -124,7 +144,31 @@ const { fn: confirmDeleteService } = useLoadingFn(async () => {
   const result = await serviceApi.deleteBinding(service.binding.guid);
   if (result.success) {
     await waitForBindingDeletion(service.binding.guid);
-    deleteDialog.value = { opened: false, service: undefined };
+
+    if (deleteDialog.value.deleteInstance) {
+      const bindingsResult = await serviceApi.getBindingsForInstance(service.guid);
+      if (bindingsResult.success) {
+        if (bindingsResult.data.resources.length === 0) {
+          const deleteInstanceResult = await serviceApi.deleteInstance(service.guid);
+          if (deleteInstanceResult.success) {
+            await waitForServiceInstanceDeletion(service.guid);
+          } else {
+            context.errors.value.push(deleteInstanceResult.error as ApiErrorResponse);
+          }
+        } else {
+          context.errors.value.push(
+            buildApiErrorResponse({
+              title: 'Service instance still in use',
+              detail: `The service instance is still bound (${bindingsResult.data.resources.length} binding(s) remaining) and cannot be deleted.`,
+            }),
+          );
+        }
+      } else {
+        context.errors.value.push(bindingsResult.error as ApiErrorResponse);
+      }
+    }
+
+    deleteDialog.value = { opened: false, service: undefined, deleteInstance: false };
     loadData();
   } else {
     context.errors.value.push(result.error as ApiErrorResponse);
@@ -143,8 +187,17 @@ const { fn: confirmDeleteService } = useLoadingFn(async () => {
 
       <confirm-dialog v-model="deleteDialog.opened" @confirm="confirmDeleteService" :loading="deleting">
         <template #text>
-          Delete service `{{ deleteDialog.service?.name }}` from application `{{ context.application.value.name }}`?
-          This removes the binding from this app.
+          <div>
+            Delete service `{{ deleteDialog.service?.name }}` from application `{{ context.application.value.name }}`?
+            This removes the binding from this app.
+          </div>
+          <v-checkbox
+            v-model="deleteDialog.deleteInstance"
+            class="mt-2"
+            color="warning"
+            hide-details
+            label="Also delete service instance after unbind">
+          </v-checkbox>
         </template>
       </confirm-dialog>
 

--- a/frontend/src/core/router.ts
+++ b/frontend/src/core/router.ts
@@ -9,6 +9,7 @@ export enum RouteNames {
   APPLICATION_SERVICES = 'APPLICATION_SERVICES',
   APPLICATION_LOG_STREAM = 'APPLICATION_LOG_STREAM',
   APPLICATIONS = 'APPLICATIONS',
+  SERVICES = 'SERVICES',
   ORGANIZATION = 'ORGANIZATION',
   ORGANIZATIONS = 'ORGANIZATIONS',
   SPACE = 'SPACE',
@@ -63,6 +64,11 @@ const router = createRouter({
       name: RouteNames.APPLICATIONS,
       path: '/applications',
       component: () => import('@/views/ApplicationsView.vue'),
+    },
+    {
+      name: RouteNames.SERVICES,
+      path: '/services',
+      component: () => import('@/views/ServicesView.vue'),
     },
 
     {

--- a/frontend/src/locales/en/menu.json
+++ b/frontend/src/locales/en/menu.json
@@ -1,4 +1,5 @@
 {
   "applications": "@:application.applications",
+  "services": "@:service.services",
   "organizations": "@:organization.organizations"
 }

--- a/frontend/src/locales/en/service.json
+++ b/frontend/src/locales/en/service.json
@@ -1,6 +1,11 @@
 {
   "service": "Service",
   "services": "Services",
+  "filter": {
+    "organization": "@:organization.organization",
+    "space": "@:space.space",
+    "text": "Filter"
+  },
   "instance": {
     "title": "Instance",
     "type": "Type"

--- a/frontend/src/locales/fr/menu.json
+++ b/frontend/src/locales/fr/menu.json
@@ -1,4 +1,5 @@
 {
   "applications": "@:application.applications",
+  "services": "@:service.services",
   "organizations": "Organisations"
 }

--- a/frontend/src/locales/fr/service.json
+++ b/frontend/src/locales/fr/service.json
@@ -1,6 +1,11 @@
 {
   "service": "Service",
   "services": "Services",
+  "filter": {
+    "organization": "@:organization.organization",
+    "space": "@:space.space",
+    "text": "Filtrer"
+  },
   "instance": {
     "title": "Instance",
     "type": "Type"

--- a/frontend/src/models/cf/service.ts
+++ b/frontend/src/models/cf/service.ts
@@ -1,5 +1,7 @@
 import { Dayjs } from 'dayjs';
 import { CFLink, CFMetaData, CFPaginated, CFResourceWithRelationShips, CFToOneRelationship } from '@/models/cf/common';
+import { CFOrganization } from '@/models/cf/organization';
+import { CFSpace } from '@/models/cf/space';
 
 export interface CFServiceInstance extends CFResourceWithRelationShips {
   name: string;
@@ -25,6 +27,10 @@ export interface CFServiceInstance extends CFResourceWithRelationShips {
     parameters: CFLink;
     shared_spaces: CFLink;
   };
+  included?: {
+    spaces: CFSpace[];
+    organizations: CFOrganization[];
+  };
 }
 
 export namespace CFServiceInstance {
@@ -42,7 +48,7 @@ export namespace CFServiceInstance {
   }
 }
 
-export type PaginatedServiceInstances = CFPaginated<CFServiceInstance>;
+export type PaginatedServiceInstances = CFPaginated<CFServiceInstance, { spaces: CFSpace[]; organizations: CFOrganization[] }>;
 
 export interface CFServiceBinding extends CFResourceWithRelationShips {
   name: string;

--- a/frontend/src/views/ApplicationView.vue
+++ b/frontend/src/views/ApplicationView.vue
@@ -2,6 +2,7 @@
 import { ApiErrorResponse, compactErrors } from '@/api';
 import applicationApi from '@/api/application';
 import ApiErrorAlert from '@/components/ApiErrorAlert.vue';
+import DeleteButton from '@/components/application/action/DeleteButton.vue';
 import RestageButton from '@/components/application/action/RestageButton.vue';
 import RestartButton from '@/components/application/action/RestartButton.vue';
 import StartButton from '@/components/application/action/StartButton.vue';
@@ -17,6 +18,7 @@ import { waitUntil } from '@/utils/common';
 import { matchesOneOf } from '@/utils/string';
 import { computed, onDeactivated, ref } from 'vue';
 import { useDisplay } from 'vuetify';
+import { useRouter } from 'vue-router';
 
 const props = defineProps<{
   guid: CFApplication['guid'];
@@ -24,7 +26,7 @@ const props = defineProps<{
 
 const loading = ref(false);
 
-type Action = 'start' | 'stop' | 'restart' | 'restage';
+type Action = 'start' | 'stop' | 'restart' | 'restage' | 'delete';
 
 const currentAction = ref<Action>();
 const handleLaunchAction = (action: Action) => {
@@ -57,11 +59,15 @@ const polling = computed({
 });
 
 const display = useDisplay();
+const router = useRouter();
 const showSectionDrawer = ref(false);
 const closeSectionDrawer = () => {
   if (display.mdAndDown.value) {
     showSectionDrawer.value = false;
   }
+};
+const handleDeleteSuccess = () => {
+  router.push({ name: RouteNames.APPLICATIONS });
 };
 
 const loadAllData = async (reset: boolean = false) => {
@@ -180,10 +186,14 @@ const restaging = computed(() => !!refRestageButton.value?.loading);
             @completed="currentAction = undefined">
           </restage-button>
 
-          <v-btn disabled>
-            <v-icon>mdi-delete-outline</v-icon>
-            <v-tooltip activator="parent" location="bottom">Delete</v-tooltip>
-          </v-btn>
+          <delete-button
+            :application="application"
+            :disabled="!!currentAction"
+            @launched="handleLaunchAction('delete')"
+            @completed="currentAction = undefined"
+            @success="handleDeleteSuccess"
+            @error="errors.push($event)">
+          </delete-button>
         </v-btn-group>
 
         <v-spacer></v-spacer>

--- a/frontend/src/views/ApplicationView.vue
+++ b/frontend/src/views/ApplicationView.vue
@@ -67,7 +67,7 @@ const closeSectionDrawer = () => {
   }
 };
 const handleDeleteSuccess = () => {
-  router.push({ name: RouteNames.APPLICATIONS });
+  router.push({ name: RouteNames.APPLICATIONS, query: { refresh: `${Date.now()}` } });
 };
 
 const loadAllData = async (reset: boolean = false) => {

--- a/frontend/src/views/ApplicationsView.vue
+++ b/frontend/src/views/ApplicationsView.vue
@@ -122,6 +122,60 @@ const { filters, data: filteredApplications } = useFilterData((filters, { includ
 });
 
 const { data: paginatedApplications, pagination } = usePagination(filteredApplications, { perPage: 20 });
+
+const cardsPerRow = ref<1 | 2 | 4>(4);
+const layoutManuallySelected = ref(false);
+const suggestedCardsPerRow = (count: number): 1 | 2 | 4 => {
+  if (count <= 1) return 1;
+  if (count < 4) return 2;
+  return 4;
+};
+const cardCols = computed(() => {
+  switch (cardsPerRow.value) {
+    case 1:
+      return 12;
+    case 2:
+      return 6;
+    case 4:
+    default:
+      return 3;
+  }
+});
+const cycleCardsPerRow = () => {
+  layoutManuallySelected.value = true;
+  switch (cardsPerRow.value) {
+    case 4:
+      cardsPerRow.value = 2;
+      break;
+    case 2:
+      cardsPerRow.value = 1;
+      break;
+    case 1:
+    default:
+      cardsPerRow.value = 4;
+      break;
+  }
+};
+const cardsPerRowIcon = computed(() => {
+  switch (cardsPerRow.value) {
+    case 4:
+      return 'mdi-view-grid-outline';
+    case 2:
+      return 'mdi-view-agenda-outline';
+    case 1:
+    default:
+      return 'mdi-view-stream-outline';
+  }
+});
+watch(
+  () => filteredApplications.value.length,
+  (count) => {
+    if (!layoutManuallySelected.value) {
+      cardsPerRow.value = suggestedCardsPerRow(count);
+    }
+  },
+  { immediate: true },
+);
 </script>
 
 <template>
@@ -177,12 +231,19 @@ const { data: paginatedApplications, pagination } = usePagination(filteredApplic
             </v-btn>
           </v-col>
 
+          <v-col cols="auto">
+            <v-btn variant="text" @click="cycleCardsPerRow" size="large">
+              <v-icon>{{ cardsPerRowIcon }}</v-icon>
+              <v-tooltip activator="parent" location="bottom">Cards per row: {{ cardsPerRow }}</v-tooltip>
+            </v-btn>
+          </v-col>
+
           <v-col cols="auto">{{ filteredApplications.length }}/{{ applications?.resources.length }}</v-col>
         </v-row>
 
         <template v-if="paginatedApplications.length > 0">
           <v-row>
-            <v-col cols="3" v-for="application in paginatedApplications" :key="`application-${application.guid}`">
+            <v-col cols="12" :md="cardCols" v-for="application in paginatedApplications" :key="`application-${application.guid}`">
               <application-item :application="application"></application-item>
             </v-col>
           </v-row>

--- a/frontend/src/views/ApplicationsView.vue
+++ b/frontend/src/views/ApplicationsView.vue
@@ -12,6 +12,7 @@ import { flatOnSuccess } from '@/utils/result';
 import { map, sortBy } from 'lodash';
 import { computed, onActivated, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
 
 const { t } = useI18n();
 
@@ -20,6 +21,7 @@ const {
   result,
   execute: loadApplications,
   loading,
+  reset: resetApplications,
 } = usePaginatedApiCall((page: number) =>
   applicationApi
     .getAll({
@@ -52,7 +54,19 @@ const {
     ),
 );
 
-onActivated(loadApplications);
+const route = useRoute();
+const forceReloadApplications = () => {
+  resetApplications();
+  loadApplications();
+};
+
+onActivated(forceReloadApplications);
+watch(
+  () => route.query.refresh,
+  () => {
+    forceReloadApplications();
+  },
+);
 
 const organizationFilter = ref<CFOrganization['guid']>();
 const organizations = computed(() => sortBy(applications.value?.included?.organizations, (item) => item.name));
@@ -158,7 +172,7 @@ const { data: paginatedApplications, pagination } = usePagination(filteredApplic
           </v-col>
 
           <v-col cols="auto">
-            <v-btn variant="text" @click="loadApplications" size="large">
+            <v-btn variant="text" @click="forceReloadApplications" size="large">
               <v-icon>mdi-cached</v-icon>
             </v-btn>
           </v-col>

--- a/frontend/src/views/ServicesView.vue
+++ b/frontend/src/views/ServicesView.vue
@@ -1,0 +1,299 @@
+<script setup lang="ts">
+import { ApiErrorResponse, compactErrors } from '@/api';
+import organizationApi from '@/api/organization';
+import serviceApi from '@/api/service';
+import spaceApi from '@/api/space';
+import ApiErrorAlert from '@/components/ApiErrorAlert.vue';
+import ServiceInstanceCardItem from '@/components/services/ServiceInstanceCardItem.vue';
+import ConfirmDialog from '@/components/shared/ConfirmDialog.vue';
+import { usePaginatedApiCall } from '@/composables/useApiCall';
+import useFilterData from '@/composables/useFilterData';
+import useLoadingFn from '@/composables/useLoadingFn';
+import usePagination from '@/composables/usePagination';
+import { CFOrganization } from '@/models/cf/organization';
+import { CFServiceInstance } from '@/models/cf/service';
+import { CFSpace } from '@/models/cf/space';
+import { map, sortBy, uniq } from 'lodash';
+import { computed, onActivated, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
+
+type RelatedResource = {
+  guid: string;
+  name: string;
+};
+
+type ServiceWithContext = CFServiceInstance & { space?: RelatedResource; organization?: RelatedResource };
+
+const { t } = useI18n();
+
+const {
+  data: servicesData,
+  result: servicesResult,
+  execute: loadServices,
+  loading: loadingServices,
+  reset: resetServices,
+} = usePaginatedApiCall((page: number) => serviceApi.getAllInstances({ page, perPage: 50 }));
+const {
+  data: spacesData,
+  result: spacesResult,
+  execute: loadSpaces,
+  loading: loadingSpaces,
+  reset: resetSpaces,
+} = usePaginatedApiCall((page: number) => spaceApi.getAll({ page, perPage: 200 }));
+const {
+  data: organizationsData,
+  result: organizationsResult,
+  execute: loadOrganizations,
+  loading: loadingOrganizations,
+  reset: resetOrganizations,
+} = usePaginatedApiCall((page: number) => organizationApi.getAll({ page, perPage: 200 }));
+
+const route = useRoute();
+const loading = computed(() => loadingServices.value || loadingSpaces.value || loadingOrganizations.value);
+const servicesError = computed(() => (!servicesResult.value?.success ? servicesResult.value?.error : undefined));
+const spacesError = computed(() => (!spacesResult.value?.success ? spacesResult.value?.error : undefined));
+const organizationsError = computed(() =>
+  !organizationsResult.value?.success ? organizationsResult.value?.error : undefined,
+);
+const error = computed(() => compactErrors(servicesError.value, spacesError.value, organizationsError.value));
+const hasLoaded = computed(
+  () => !!servicesResult.value && !!spacesResult.value && !!organizationsResult.value && !loading.value,
+);
+
+const forceReloadServices = () => {
+  resetServices();
+  resetSpaces();
+  resetOrganizations();
+  loadServices();
+  loadSpaces();
+  loadOrganizations();
+};
+
+onActivated(forceReloadServices);
+watch(
+  () => route.query.refresh,
+  () => {
+    forceReloadServices();
+  },
+);
+
+const organizationFilter = ref<CFOrganization['guid']>();
+const organizationsByGuid = computed(
+  () => new Map((organizationsData.value?.resources ?? []).map((org) => [org.guid, org])),
+);
+const spacesByGuid = computed(() => new Map((spacesData.value?.resources ?? []).map((space) => [space.guid, space])));
+
+const services = computed<ServiceWithContext[]>(() =>
+  (servicesData.value?.resources ?? []).map((service) => {
+    const space = spacesByGuid.value.get(service.relationships.space.data.guid);
+    const organization = space ? organizationsByGuid.value.get(space.relationships.organization.data.guid) : undefined;
+
+    return {
+      ...service,
+      space: space && {
+        name: space.name,
+        guid: space.guid,
+      },
+      organization: organization && {
+        name: organization.name,
+        guid: organization.guid,
+      },
+    };
+  }),
+);
+
+const organizations = computed(() => {
+  const orgGuids = uniq(services.value.map((service) => service.organization?.guid).filter((item): item is string => !!item));
+  return sortBy(
+    orgGuids
+      .map((guid) => organizationsByGuid.value.get(guid))
+      .filter((item): item is CFOrganization => !!item),
+    (item) => item.name,
+  );
+});
+
+const spaceFilter = ref<CFSpace['guid']>();
+const spaces = computed(() => {
+  if (!spacesData.value?.resources) {
+    return [];
+  }
+
+  const referencedSpaceGuids = new Set(services.value.map((service) => service.space?.guid).filter((item): item is string => !!item));
+  const filteredSpaces = spacesData.value.resources.filter((space) => {
+    const orgFilter = organizationFilter.value;
+    return referencedSpaceGuids.has(space.guid) && (!orgFilter || space.relationships.organization.data.guid === orgFilter);
+  });
+
+  return sortBy(
+    map(filteredSpaces, (space) => {
+      let displayName: string;
+
+      if (filteredSpaces.filter((s) => s.name === space.name).length > 1) {
+        const organization = organizations.value.find((org) => org.guid === space.relationships.organization.data.guid);
+
+        displayName = `${space.name} (${organization?.name ?? '--'})`;
+      } else {
+        displayName = space.name;
+      }
+
+      return { ...space, displayName };
+    }),
+    (item) => item.displayName,
+  );
+});
+
+watch(
+  organizationFilter,
+  () => {
+    spaceFilter.value = spaces.value.length === 1 ? spaces.value[0]?.guid : undefined;
+  },
+  { flush: 'post' },
+);
+
+const { filters, data: filteredServices } = useFilterData((filters, { includesText }) => {
+  const organization = organizationFilter.value;
+  const space = spaceFilter.value;
+
+  return services.value.filter((service) => {
+    return (
+      (!organization || service.organization?.guid === organization) &&
+      (!space || service.space?.guid === space) &&
+      (!filters.text || includesText(service.name, service.space?.name, service.organization?.name))
+    );
+  });
+});
+
+const { data: paginatedServices, pagination } = usePagination(filteredServices, { perPage: 20 });
+
+const deletingGuid = ref<CFServiceInstance['guid']>();
+const deletingError = ref<ApiErrorResponse>();
+const deleteDialog = ref<{ opened: boolean; service?: ServiceWithContext }>({ opened: false, service: undefined });
+const askDelete = (service: ServiceWithContext) => {
+  deleteDialog.value = { opened: true, service };
+};
+
+const wait = (delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs));
+const waitForServiceDeletion = async (serviceGuid: CFServiceInstance['guid']) => {
+  for (let i = 0; i < 20; i++) {
+    const current = await serviceApi.getInstances([serviceGuid]);
+    if (!current.success) {
+      break;
+    }
+
+    const exists = current.data.resources.some((service) => service.guid === serviceGuid);
+    if (!exists) {
+      return;
+    }
+
+    await wait(1000);
+  }
+};
+
+const { fn: confirmDeleteService, loading: deleting } = useLoadingFn(async () => {
+  const service = deleteDialog.value.service;
+  if (!service) return;
+
+  deletingError.value = undefined;
+  deletingGuid.value = service.guid;
+  const result = await serviceApi.deleteInstance(service.guid);
+  if (result.success) {
+    await waitForServiceDeletion(service.guid);
+    deleteDialog.value = { opened: false, service: undefined };
+    forceReloadServices();
+  } else {
+    deletingError.value = result.error;
+  }
+  deletingGuid.value = undefined;
+});
+</script>
+
+<template>
+  <v-container fluid>
+    <v-progress-linear indeterminate :color="loading ? 'primary' : 'transparent'" class="mb-1"></v-progress-linear>
+
+    <template v-if="hasLoaded || error">
+      <v-row v-if="error">
+        <v-col><api-error-alert :error="error"></api-error-alert></v-col>
+      </v-row>
+
+      <template v-else-if="hasLoaded">
+        <v-row v-if="deletingError">
+          <v-col><api-error-alert :error="deletingError"></api-error-alert></v-col>
+        </v-row>
+
+        <confirm-dialog v-model="deleteDialog.opened" @confirm="confirmDeleteService" :loading="deleting">
+          <template #text>Delete service instance `{{ deleteDialog.service?.name }}`?</template>
+        </confirm-dialog>
+
+        <v-row align="center">
+          <v-col>
+            <v-select
+              :label="t('service.filter.organization')"
+              density="compact"
+              v-model="organizationFilter"
+              :items="organizations"
+              item-title="name"
+              item-value="guid"
+              clearable
+              hide-details>
+            </v-select>
+          </v-col>
+
+          <v-col>
+            <v-select
+              :label="t('service.filter.space')"
+              density="compact"
+              v-model="spaceFilter"
+              :items="spaces"
+              item-title="displayName"
+              item-value="guid"
+              clearable
+              hide-details>
+            </v-select>
+          </v-col>
+
+          <v-col>
+            <v-text-field
+              :label="t('service.filter.text')"
+              density="compact"
+              v-model="filters.text"
+              clearable
+              hide-details>
+            </v-text-field>
+          </v-col>
+
+          <v-col cols="auto">
+            <v-btn variant="text" @click="forceReloadServices" size="large">
+              <v-icon>mdi-cached</v-icon>
+            </v-btn>
+          </v-col>
+
+          <v-col cols="auto">{{ filteredServices.length }}/{{ services.length }}</v-col>
+        </v-row>
+
+        <template v-if="paginatedServices.length > 0">
+          <v-row>
+            <v-col cols="3" v-for="service in paginatedServices" :key="`service-${service.guid}`">
+              <service-instance-card-item
+                :service="service"
+                :deleting="deletingGuid === service.guid"
+                @delete="askDelete(service)">
+              </service-instance-card-item>
+            </v-col>
+          </v-row>
+
+          <v-row>
+            <v-col>
+              <v-pagination v-model="pagination.page" :length="pagination.pages"></v-pagination>
+            </v-col>
+          </v-row>
+        </template>
+
+        <v-alert class="mt-2" color="warning" variant="outlined" icon="$warning" v-else-if="!loading">
+          No service found
+        </v-alert>
+      </template>
+    </template>
+  </v-container>
+</template>

--- a/frontend/src/views/ServicesView.vue
+++ b/frontend/src/views/ServicesView.vue
@@ -165,6 +165,59 @@ const { filters, data: filteredServices } = useFilterData((filters, { includesTe
 });
 
 const { data: paginatedServices, pagination } = usePagination(filteredServices, { perPage: 20 });
+const cardsPerRow = ref<1 | 2 | 4>(4);
+const layoutManuallySelected = ref(false);
+const suggestedCardsPerRow = (count: number): 1 | 2 | 4 => {
+  if (count <= 1) return 1;
+  if (count < 4) return 2;
+  return 4;
+};
+const cardCols = computed(() => {
+  switch (cardsPerRow.value) {
+    case 1:
+      return 12;
+    case 2:
+      return 6;
+    case 4:
+    default:
+      return 3;
+  }
+});
+const cycleCardsPerRow = () => {
+  layoutManuallySelected.value = true;
+  switch (cardsPerRow.value) {
+    case 4:
+      cardsPerRow.value = 2;
+      break;
+    case 2:
+      cardsPerRow.value = 1;
+      break;
+    case 1:
+    default:
+      cardsPerRow.value = 4;
+      break;
+  }
+};
+const cardsPerRowIcon = computed(() => {
+  switch (cardsPerRow.value) {
+    case 4:
+      return 'mdi-view-grid-outline';
+    case 2:
+      return 'mdi-view-agenda-outline';
+    case 1:
+    default:
+      return 'mdi-view-stream-outline';
+  }
+});
+watch(
+  () => filteredServices.value.length,
+  (count) => {
+    if (!layoutManuallySelected.value) {
+      cardsPerRow.value = suggestedCardsPerRow(count);
+    }
+  },
+  { immediate: true },
+);
 
 const deletingGuid = ref<CFServiceInstance['guid']>();
 const deletingError = ref<ApiErrorResponse>();
@@ -269,12 +322,19 @@ const { fn: confirmDeleteService, loading: deleting } = useLoadingFn(async () =>
             </v-btn>
           </v-col>
 
+          <v-col cols="auto">
+            <v-btn variant="text" @click="cycleCardsPerRow" size="large">
+              <v-icon>{{ cardsPerRowIcon }}</v-icon>
+              <v-tooltip activator="parent" location="bottom">Cards per row: {{ cardsPerRow }}</v-tooltip>
+            </v-btn>
+          </v-col>
+
           <v-col cols="auto">{{ filteredServices.length }}/{{ services.length }}</v-col>
         </v-row>
 
         <template v-if="paginatedServices.length > 0">
           <v-row>
-            <v-col cols="3" v-for="service in paginatedServices" :key="`service-${service.guid}`">
+            <v-col cols="12" :md="cardCols" v-for="service in paginatedServices" :key="`service-${service.guid}`">
               <service-instance-card-item
                 :service="service"
                 :deleting="deletingGuid === service.guid"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -29,4 +29,7 @@ export default defineConfig({
   resolve: {
     alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
   },
+  build: {
+    chunkSizeWarningLimit: 1000,
+  },
 });


### PR DESCRIPTION
## Summary
- implement application delete action with confirmation (DELETE /v3/apps/:guid) and refresh navigation back to Applications on success
- add app-level service removal in Application > Services: unbind service credential binding from the app
- extend service removal flow with optional service instance deletion after unbind, including safeguards when bindings still exist
- add top-level Services page and main menu entry, with service cards, delete action, and filters by Organization, Space, and name
- adjust services loading to avoid unsupported include query parameter on /v3/service_instances by resolving spaces/organizations through compatible API calls
- improve delete reliability by waiting for backend completion before reloading lists
- add compact cards-per-row control (icon-based cycle) on Applications, Services, and Application > Services lists
- add adaptive default card density: 1 item => 1/row, 2-3 items => 2/row, 4+ items => 4/row
- fix repeated error flood and UX by deduplicating identical API errors and making alert close/dismiss work
- raise build warning thresholds: backend bundle warning now starts at 2.5 MB, and frontend Vite chunk warning limit is 1 MB

